### PR TITLE
fixed .git typo in sample config

### DIFF
--- a/sample_config.py
+++ b/sample_config.py
@@ -3,7 +3,7 @@ wpaths = ["/home/username/path1/", "/home/username/path2/"]
 
 # exclude list for rsync
 rexcludes = [
-	"/.git",
+	".git/",
 ]
 
 # rpaths has one-to-one correspondence with wpaths for syncing multiple directories


### PR DESCRIPTION
Hi Benedikt, 

Found that .git directories were being synced using the sample config, thought that this typo should be fixed.

Cheers,
Jamie