### PR TITLE
Improvement with rsync spawning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ except ``/var/www/localhost`` to 3 remote locations:
   #]
 
   # event delay in seconds (this prevents huge
-  # amounts of syncs, but dicreases the 
+  # amounts of syncs, but dicreases the
   # realtime side of things)
   #edelay = 10
 
@@ -95,11 +95,6 @@ Bugs
 There are no known bugs currently, however, due to the design of inosync, there
 are several shortcomings:
 
-- inosync cannot parse rsync excludes and therefore calls rsync on changes in
-  excluded directories as well. (`of course rsync still excludes these
-  directories`)
-- It is easily possible to flood the daemon with huge amounts of change events,
-  potentially resulting in enormous bandwidth and connection usage.
 - Excludes currently apply to each path to be synced and there is no way to specify per-path excludes yet.
 
 Requirements

--- a/inosync.py
+++ b/inosync.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python
 # vim: set fileencoding=utf-8 ts=2 sw=2 expandtab :
 
-import os,sys
-from optparse import OptionParser,make_option
+import os
+import sys
+from optparse import OptionParser, make_option
 from time import sleep
 from syslog import *
 from pyinotify import *
@@ -12,29 +13,29 @@ import datetime
 
 __author__ = "Benedikt Böhm"
 __copyright__ = "Copyright (c) 2007-2008 Benedikt Böhm <bb@xnull.de>"
-__version__ = 0,2,3
+__version__ = 0, 2, 3
 
 OPTION_LIST = [
-  make_option(
-      "-c", dest = "config",
-      default = "/etc/inosync/default.py",
-      metavar = "FILE",
-      help = "load configuration from FILE"),
-  make_option(
-      "-d", dest = "daemonize",
-      action = "store_true",
-      default = False,
-      help = "daemonize %prog"),
-  make_option(
-      "-p", dest = "pretend",
-      action = "store_true",
-      default = False,
-      help = "do not actually call rsync"),
-  make_option(
-      "-v", dest = "verbose",
-      action = "store_true",
-      default = False,
-      help = "print debugging information"),
+    make_option(
+        "-c", dest="config",
+        default="/etc/inosync/default.py",
+        metavar="FILE",
+        help="load configuration from FILE"),
+    make_option(
+        "-d", dest="daemonize",
+        action="store_true",
+        default=False,
+        help="daemonize %prog"),
+    make_option(
+        "-p", dest="pretend",
+        action="store_true",
+        default=False,
+        help="do not actually call rsync"),
+    make_option(
+        "-v", dest="verbose",
+        action="store_true",
+        default=False,
+        help="print debugging information"),
 ]
 
 DEFAULT_EVENTS = [
@@ -46,6 +47,7 @@ DEFAULT_EVENTS = [
 ]
 
 changed_paths = Queue.Queue()
+
 
 def sync_changes():
     q_len = changed_paths.qsize()
@@ -68,175 +70,181 @@ t = Timer(10.0, sync_changes)
 t.daemon = True
 t.start()
 
+
 class RsyncEvent(ProcessEvent):
-  pretend = None
+    pretend = None
 
-  def __init__(self, pretend=False):
-    self.pretend = pretend
+    def __init__(self, pretend=False):
+        self.pretend = pretend
 
-  def sync(self, wpath):
-    args = [config.rsync, "-ltrp", "--delete"]
-    if config.extra:
-      args.append(config.extra)
-    args.append("--bwlimit=%s" % config.rspeed)
-    if config.logfile:
-      args.append("--log-file=%s" % config.logfile)
-    if "rexcludes" in dir(config):
-      for rexclude in config.rexcludes:
-        args.append("--exclude=%s" % rexclude)
-    args.append(wpath)
-    rpath = config.rpaths[config.wpaths.index(wpath)]
-    args.append("%s")
-    cmd = " ".join(args)
-    for node in config.rnodes:
-      if self.pretend:
-        syslog("would execute `%s'" % (cmd % (node + rpath)))
-      else:
-        syslog(LOG_DEBUG, "executing %s" % (cmd % (node + rpath)))
-        proc = os.popen(cmd % (node + rpath))
-        for line in proc:
-          syslog(LOG_DEBUG, "[rsync] %s" % line.strip())
+    def sync(self, wpath):
+        args = [config.rsync, "-ltrp", "--delete"]
+        if config.extra:
+            args.append(config.extra)
+        args.append("--bwlimit=%s" % config.rspeed)
+        if config.logfile:
+            args.append("--log-file=%s" % config.logfile)
+        if "rexcludes" in dir(config):
+            for rexclude in config.rexcludes:
+                args.append("--exclude=%s" % rexclude)
+        args.append(wpath)
+        rpath = config.rpaths[config.wpaths.index(wpath)]
+        args.append("%s")
+        cmd = " ".join(args)
+        for node in config.rnodes:
+            if self.pretend:
+                syslog("would execute `%s'" % (cmd % (node + rpath)))
+            else:
+                syslog(LOG_DEBUG, "executing %s" % (cmd % (node + rpath)))
+                proc = os.popen(cmd % (node + rpath))
+                for line in proc:
+                    syslog(LOG_DEBUG, "[rsync] %s" % line.strip())
 
-  def process_default(self, event):
-    syslog(LOG_DEBUG, "caught %s on %s" % \
-        (event.maskname, os.path.join(event.path, event.name)))
-    for wpath in config.wpaths:
-      if os.path.realpath(wpath) in os.path.realpath(event.path):
-        changed_paths.put(os.path.realpath(event.path))
+    def process_default(self, event):
+        syslog(LOG_DEBUG, "caught %s on %s" %
+               (event.maskname, os.path.join(event.path, event.name)))
+        for wpath in config.wpaths:
+            if os.path.realpath(wpath) in os.path.realpath(event.path):
+                changed_paths.put(os.path.realpath(event.path))
+
 
 def daemonize():
-  try:
-    pid = os.fork()
-  except OSError, e:
-    raise Exception, "%s [%d]" % (e.strerror, e.errno)
-
-  if (pid == 0):
-    os.setsid()
     try:
-      pid = os.fork()
+        pid = os.fork()
     except OSError, e:
-      raise Exception, "%s [%d]" % (e.strerror, e.errno)
+        raise Exception("%s [%d]" % (e.strerror, e.errno))
+
     if (pid == 0):
-      os.chdir('/')
-      os.umask(0)
+        os.setsid()
+        try:
+            pid = os.fork()
+        except OSError, e:
+            raise Exception("%s [%d]" % (e.strerror, e.errno))
+        if (pid == 0):
+            os.chdir('/')
+            os.umask(0)
+        else:
+            os._exit(0)
     else:
-      os._exit(0)
-  else:
-    os._exit(0)
+        os._exit(0)
 
-  os.open("/dev/null", os.O_RDWR)
-  os.dup2(0, 1)
-  os.dup2(0, 2)
+    os.open("/dev/null", os.O_RDWR)
+    os.dup2(0, 1)
+    os.dup2(0, 2)
 
-  return 0
+    return 0
+
 
 def load_config(filename):
-  if not os.path.isfile(filename):
-    raise RuntimeError, "Configuration file does not exist: %s" % filename
+    if not os.path.isfile(filename):
+        raise RuntimeError("Configuration file does not exist: %s" % filename)
 
-  configdir  = os.path.dirname(filename)
-  configfile = os.path.basename(filename)
+    configdir = os.path.dirname(filename)
+    configfile = os.path.basename(filename)
 
-  if configfile.endswith(".py"):
-    configfile = configfile[0:-3]
-  else:
-    raise RuntimeError, "Configuration file must be a importable python file ending in .py"
+    if configfile.endswith(".py"):
+        configfile = configfile[0:-3]
+    else:
+        raise RuntimeError("Configuration file must be a importable python file ending in .py")
 
-  sys.path.append(configdir)
-  exec("import %s as __config__" % configfile)
-  sys.path.remove(configdir)
+    sys.path.append(configdir)
+    exec("import %s as __config__" % configfile)
+    sys.path.remove(configdir)
 
-  global config
-  config = __config__
+    global config
+    config = __config__
 
-  if not "wpaths" in dir(config):
-    raise RuntimeError, "no paths given to watch"
-  for wpath in config.wpaths:
-    if not os.path.isdir(wpath):
-      raise RuntimeError, "one of the watch paths does not exist: %s" % wpath
-    if not os.path.isabs(wpath):
-      config.wpaths[config.wpaths.index(wpath)] = os.path.abspath(wpath)
-
-  for owpath in config.wpaths:
+    if "wpaths" not in dir(config):
+        raise RuntimeError("no paths given to watch")
     for wpath in config.wpaths:
-      if os.path.realpath(owpath) in os.path.realpath(wpath) and wpath != owpath and len(os.path.split(wpath)) <> len(os.path.split(owpath)):
-	raise RuntimeError, "You cannot specify %s in wpaths which is a subdirectory of %s since it is already synced." % (wpath, owpath)
+        if not os.path.isdir(wpath):
+            raise RuntimeError("one of the watch paths does not exist: %s" % wpath)
+        if not os.path.isabs(wpath):
+            config.wpaths[config.wpaths.index(wpath)] = os.path.abspath(wpath)
 
+    for owpath in config.wpaths:
+        for wpath in config.wpaths:
+            if os.path.realpath(owpath) in os.path.realpath(wpath) and wpath != owpath and len(os.path.split(wpath)) != len(os.path.split(owpath)):
+                raise RuntimeError("You cannot specify %s in wpaths which is a subdirectory of %s since it is already synced." % (wpath, owpath))
 
-  if not "rpaths" in dir(config):
-    raise RuntimeError, "no paths given for the transfer"
-  if len(config.wpaths) != len(config.rpaths):
-    raise RuntimeError, "the no. of remote paths must be equal to the number of watched paths"
+    if "rpaths" not in dir(config):
+        raise RuntimeError("no paths given for the transfer")
+    if len(config.wpaths) != len(config.rpaths):
+        raise RuntimeError("the no. of remote paths must be equal to the number of watched paths")
 
+    if "rnodes" not in dir(config) or len(config.rnodes) < 1:
+        raise RuntimeError("no remote nodes given")
 
+    if "rspeed" not in dir(config) or config.rspeed < 0:
+        config.rspeed = 0
 
-  if not "rnodes" in dir(config) or len(config.rnodes) < 1:
-    raise RuntimeError, "no remote nodes given"
+    if "emask" not in dir(config):
+        config.emask = DEFAULT_EVENTS
+    for event in config.emask:
+        if event not in EventsCodes.ALL_FLAGS.keys():
+            raise RuntimeError("invalid inotify event: %s" % event)
 
-  if not "rspeed" in dir(config) or config.rspeed < 0:
-    config.rspeed = 0
+    if "edelay" not in dir(config):
+        config.edelay = 10
+    if config.edelay < 0:
+        raise RuntimeError("event delay needs to be greater or equal to 0")
 
-  if not "emask" in dir(config):
-    config.emask = DEFAULT_EVENTS
-  for event in config.emask:
-    if not event in EventsCodes.ALL_FLAGS.keys():
-      raise RuntimeError, "invalid inotify event: %s" % event
+    if "logfile" not in dir(config):
+        config.logfile = None
 
-  if not "edelay" in dir(config):
-    config.edelay = 10
-  if config.edelay < 0:
-    raise RuntimeError, "event delay needs to be greater or equal to 0"
+    if "extra" not in dir(config):
+        config.extra = ""
+    if "extra" not in dir(config):
+        config.inotify_excludes = []
 
-  if not "logfile" in dir(config):
-    config.logfile = None
+    if "rsync" not in dir(config):
+        config.rsync = "/usr/bin/rsync"
+    if not os.path.isabs(config.rsync):
+        raise RuntimeError("rsync path needs to be absolute")
+    if not os.path.isfile(config.rsync):
+        raise RuntimeError("rsync binary does not exist: %s" % config.rsync)
 
-  if not "extra" in dir(config):
-    config.extra = ""
-  if not "extra" in dir(config):
-    config.inotify_excludes = []
-
-  if not "rsync" in dir(config):
-    config.rsync = "/usr/bin/rsync"
-  if not os.path.isabs(config.rsync):
-    raise RuntimeError, "rsync path needs to be absolute"
-  if not os.path.isfile(config.rsync):
-    raise RuntimeError, "rsync binary does not exist: %s" % config.rsync
 
 def main():
-  version = ".".join(map(str, __version__))
-  parser = OptionParser(option_list=OPTION_LIST,version="%prog " + version)
-  (options, args) = parser.parse_args()
+    version = ".".join(map(str, __version__))
+    parser = OptionParser(option_list=OPTION_LIST, version="%prog " + version)
+    (options, args) = parser.parse_args()
 
-  if len(args) > 0:
-    parser.error("too many arguments")
+    if len(args) > 0:
+        parser.error("too many arguments")
 
-  logopt = LOG_PID|LOG_CONS
-  if not options.daemonize:
-    logopt |= LOG_PERROR
-  openlog("inosync", logopt, LOG_DAEMON)
-  if options.verbose:
-    setlogmask(LOG_UPTO(LOG_DEBUG))
-  else:
-    setlogmask(LOG_UPTO(LOG_INFO))
+    logopt = LOG_PID | LOG_CONS
+    if not options.daemonize:
+        logopt |= LOG_PERROR
+    openlog("inosync", logopt, LOG_DAEMON)
+    if options.verbose:
+        setlogmask(LOG_UPTO(LOG_DEBUG))
+    else:
+        setlogmask(LOG_UPTO(LOG_INFO))
 
-  load_config(options.config)
+    load_config(options.config)
 
-  if options.daemonize:
-    daemonize()
+    if options.daemonize:
+        daemonize()
 
-  wm = WatchManager()
-  ev = RsyncEvent(options.pretend)
-  notifier = AsyncNotifier(wm, ev, read_freq=config.edelay)
-  mask = reduce(lambda x,y: x|y, [EventsCodes.ALL_FLAGS[e] for e in config.emask])
-  wds = wm.add_watch(config.wpaths, mask, rec=True, auto_add=True,
-	exclude_filter=ExcludeFilter(config.inotify_excludes))
-  for wpath in config.wpaths:
-    syslog(LOG_DEBUG, "starting initial synchronization on %s" % wpath)
-    ev.sync(wpath)
-    syslog(LOG_DEBUG, "initial synchronization on %s done" % wpath)
-    syslog("resuming normal operations on %s" % wpath)
-  asyncore.loop()
-  sys.exit(0)
+    wm = WatchManager()
+    ev = RsyncEvent(options.pretend)
+    AsyncNotifier(wm, ev, read_freq=config.edelay)
+    mask = reduce(lambda x, y: x | y, [EventsCodes.ALL_FLAGS[e] for e in config.emask])
+    wm.add_watch(
+        config.wpaths,
+        mask,
+        rec=True,
+        auto_add=True,
+        exclude_filter=ExcludeFilter(config.inotify_excludes)
+        )
+    for wpath in config.wpaths:
+        syslog(LOG_DEBUG, "starting initial synchronization on %s" % wpath)
+        ev.sync(wpath)
+        syslog(LOG_DEBUG, "initial synchronization on %s done" % wpath)
+        syslog("resuming normal operations on %s" % wpath)
+    asyncore.loop()
+    sys.exit(0)
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/inosync.py
+++ b/inosync.py
@@ -50,17 +50,25 @@ changed_paths = Queue.Queue()
 
 
 def purge(dir):
+    """
+    Purge all old inosync temp files.
+    Cool thing is if rsync is still running it can still read the file.
+    """
     for f in os.listdir(dir):
         if "inosync_" in f:
             os.remove(os.path.join(dir, f))
 
 
 def sync_changes(pretend, sleep_time):
+    """
+    Main sync changes threads, that over a given time period processes a batch
+    of changed files.
+    """
     global config
 
     while True:
         # remove old changed files.
-        # purge("/tmp/")
+        purge("/tmp/")
 
         q_len = changed_paths.qsize()
         wpath_path_map = {}
@@ -82,11 +90,11 @@ def sync_changes(pretend, sleep_time):
                         _filepath = "./"
                     wpath_path_map[wpath].update([_filepath])
 
-            print(wpath_path_map)
+            syslog(LOG_DEBUG, wpath_path_map)
 
             for wpath, paths in wpath_path_map.items():
                 sync_filepath = "/tmp/inosync_%s" % (datetime.datetime.now().strftime('%H-%M-%s'))
-                print(paths)
+
                 with open(sync_filepath, "w") as f:
                     f.write("\n".join(paths))
                 r_sync(pretend=pretend, wpath=wpath, from_file=sync_filepath)

--- a/inosync.py
+++ b/inosync.py
@@ -60,7 +60,7 @@ def sync_changes(pretend, sleep_time):
 
     while True:
         # remove old changed files.
-        purge("/tmp/")
+        # purge("/tmp/")
 
         q_len = changed_paths.qsize()
         wpath_path_map = {}
@@ -74,9 +74,13 @@ def sync_changes(pretend, sleep_time):
             for wpath in config.wpaths:
                 while len(file_list) > 0:
                     _filepath = file_list.pop()
-                    if wpath in _filepath:
+                    r_path = wpath if wpath[len(wpath)-1] == "/" else wpath + "/"
+                    if r_path in _filepath:
                         wpath_path_map[wpath] = set()
-                    wpath_path_map[wpath].update([_filepath.replace(wpath, '') + "/"])
+                    _filepath = _filepath.replace(r_path, '')
+                    if len(_filepath) == 0:
+                        _filepath = "./"
+                    wpath_path_map[wpath].update([_filepath])
 
             print(wpath_path_map)
 
@@ -93,7 +97,7 @@ def sync_changes(pretend, sleep_time):
 
 
 def r_sync(pretend, wpath, from_file=None, delete_from_file=False):
-    args = [config.rsync, "-ltrp", "--delete"]
+    args = [config.rsync, "-avz", "--delete"]
     if config.extra:
         args.append(config.extra)
     args.append("--bwlimit=%s" % config.rspeed)

--- a/inosync.py
+++ b/inosync.py
@@ -167,6 +167,9 @@ def load_config(filename):
 
   if not "extra" in dir(config):
     config.extra = ""
+  if not "extra" in dir(config):
+    config.inotify_excludes = []
+
   if not "rsync" in dir(config):
     config.rsync = "/usr/bin/rsync"
   if not os.path.isabs(config.rsync):
@@ -200,7 +203,8 @@ def main():
   ev = RsyncEvent(options.pretend)
   notifier = AsyncNotifier(wm, ev, read_freq=config.edelay)
   mask = reduce(lambda x,y: x|y, [EventsCodes.ALL_FLAGS[e] for e in config.emask])
-  wds = wm.add_watch(config.wpaths, mask, rec=True, auto_add=True)
+  wds = wm.add_watch(config.wpaths, mask, rec=True, auto_add=True, 
+	exclude_filter=pyinotify.ExcludeFilter(config.inotify_excludes))
   for wpath in config.wpaths:
     syslog(LOG_DEBUG, "starting initial synchronization on %s" % wpath)
     ev.sync(wpath)

--- a/sample_config.py
+++ b/sample_config.py
@@ -15,6 +15,12 @@ rnodes = [
 	"username2@server2.com:",
 ]
 
+# patterns to exclude listening from
+# inotify_excludes = [
+# 	".glusterfs",
+# 	"LOGS",
+# ]
+
 # extra, raw parameters to rsync
 #extra = "--rsh=ssh -a"
 
@@ -39,3 +45,6 @@ logfile = "/home/username/inosync.log"
 
 # rsync binary path
 #rsync = "/usr/bin/rsync"
+
+# how often you want to create a batched rsync
+sleep_time = 30


### PR DESCRIPTION
Ok, so this is a terribly big pull request. But I feel it could with some proper review be a great addition to the mainline inosync. What these changes do:

 - PEP8 spacing, for improved future hackability (this is off course optional).
 - Creates a queue that all the changed paths get put into, then instead of running rsync on subpath - it instead runs a batch rsync with a list of the changed subpaths only. Doing it this way one can trade of realtime vs bulk time situations.
 - Adds a exclusion list to the inotify watch side of things.

Basically using this takes away to bugs listed in the README :smile:  Please have a look at let me know what should fixed or added.
